### PR TITLE
fix appName usage in cmd package

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -38,7 +38,7 @@ func chainsAddCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s ch a evm chains/eth.toml 
-$ %s chains add evm chains/eth.toml`, appName, appName)),
+$ %s chains add evm chains/eth.toml`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			filePath := args[1]
@@ -59,7 +59,7 @@ func chainsDeleteCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains delete eth
-$ %s ch d eth`, appName, appName)),
+$ %s ch d eth`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 
@@ -81,7 +81,7 @@ func chainsListCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s chains list
-$ %s ch l`, appName, appName)),
+$ %s ch l`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if app.Config == nil {
 				return fmt.Errorf("config is not initialized")
@@ -114,7 +114,7 @@ func chainsShowCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s ch s eth
-$ %s chains show eth --yaml`, appName, appName)),
+$ %s chains show eth --yaml`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,7 +36,7 @@ func configShowCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config show --home %s
-$ %s cfg list`, appName, defaultHome, appName)),
+$ %s cfg list`, app.Name, defaultHome, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if app.Config == nil {
 				return fmt.Errorf("config is not initialized")
@@ -63,7 +63,7 @@ func configInitCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s config init --home %s
-$ %s cfg i`, appName, defaultHome, appName)),
+$ %s cfg i`, app.Name, defaultHome, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			filePath, err := cmd.Flags().GetString(flagFile)
 			if err != nil {

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -69,7 +69,7 @@ func keysAddCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys add eth test-key
-$ %s k a eth test-key`, appName, appName)),
+$ %s k a eth test-key`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			chainName := args[0]
 			keyName := args[1]
@@ -184,7 +184,7 @@ func keysDeleteCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys delete eth test-key 
-$ %s k d eth test-key`, appName, appName)),
+$ %s k d eth test-key`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			keyName := args[1]
@@ -204,7 +204,7 @@ func keysListCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys list eth
-$ %s k l eth`, appName, appName)),
+$ %s k l eth`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			keys, err := app.ListKeys(chainName)
@@ -234,7 +234,7 @@ func keysExportCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys export eth test-key
-$ %s k e eth test-key`, appName, appName)),
+$ %s k e eth test-key`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			keyName := args[1]
@@ -261,7 +261,7 @@ func keysShowCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s keys show eth test-key
-$ %s k s eth test-key`, appName, appName)),
+$ %s k s eth test-key`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			keyName := args[1]

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -36,7 +36,7 @@ func queryTunnelCmd(app *relayer.App) *cobra.Command {
 		Short:   "Query commands on tunnel data",
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
-$ %s query tunnel 1`, appName)),
+$ %s query tunnel 1`, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tunnelID, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
@@ -69,7 +69,7 @@ func queryPacketCmd(app *relayer.App) *cobra.Command {
 		Short:   "Query commands on packet data",
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
-$ %s query packet 1 1`, appName)),
+$ %s query packet 1 1`, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tunnelID, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
@@ -108,7 +108,7 @@ func queryBalanceCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(2)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s query balance eth test-key
-$ %s q b eth test-key`, appName, appName)),
+$ %s q b eth test-key`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainName := args[0]
 			keyName := args[1]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
 	"syscall"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 )
 
 const (
-	appName         = "falcon"
 	defaultCoinType = 60
 
 	PassphraseEnvKey = "PASSPHRASE"
@@ -33,20 +31,25 @@ var defaultHome = filepath.Join(os.Getenv("HOME"), ".falcon")
 func NewRootCmd(log *zap.Logger) *cobra.Command {
 	passphrase := os.Getenv(PassphraseEnvKey)
 	homePath := defaultHome
-	app := falcon.NewApp(log, nil, passphrase, nil)
+	app := falcon.NewApp("falcon", log, nil, passphrase, nil)
 
 	// RootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
-		Use:   appName,
-		Short: "Falcon relays tss tunnel messages from BandChain to destination chains/smart contracts",
-		Long: strings.TrimSpace(`This application has:
+		Use: app.Name,
+		Short: fmt.Sprintf(
+			"%s relays tss tunnel messages from BandChain to destination chains/smart contracts",
+			app.Name,
+		),
+		Long: fmt.Sprintf(`This application has:
    1. Configuration Management: Handles the configuration of the program.
    2. Key Management: Supports managing multiple keys across multiple chains.
    3. Transaction Execution: Enables executing transactions on destination chains.
    4. Query Functionality: Facilitates querying data from both source and destination chains.
 
    NOTE: Most of the commands have aliases that make typing them much quicker 
-         (i.e. 'falcon tx', 'falcon q', etc...)`),
+         (i.e. '%s tx', '%s q', etc...)`,
+			app.Name, app.Name,
+		),
 	}
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) (err error) {
@@ -159,7 +162,7 @@ func Execute() error {
 		// But if a case is reached, panic so that we get a non-zero exit and a dump of remaining goroutines.
 		select {
 		case <-time.After(time.Minute):
-			panic(errors.New("falcon did not shut down within one minute of interrupt"))
+			panic(errors.New("program did not shut down within one minute of interrupt"))
 		case sig := <-sigCh:
 			panic(fmt.Errorf("received signal %v; forcing quit", sig))
 		}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -15,12 +15,12 @@ func StartCmd(app *relayer.App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "start",
 		Aliases: []string{"st"},
-		Short:   "Start the falcon tunnel relayer program",
+		Short:   fmt.Sprintf("Start the %s tunnel relayer program", app.Name),
 		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s start                             # start relaying data from every tunnel being registered on source chain.
 $ %s start --tunnel-ids 1,12           # start relaying data from specific tunnelIDs.
-$ %s start --tunnel-creator 0xABC123   # start relaying data from tunnels created by a specific address`, appName, appName, appName)),
+$ %s start --tunnel-creator 0xABC123   # start relaying data from tunnels created by a specific address`, app.Name, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			argsTunnelIDs, err := cmd.Flags().GetUintSlice(flagTunnelIds)
 			if err != nil {

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -17,9 +17,12 @@ func TransactionCmd(app *relayer.App) *cobra.Command {
 		Use:     "transact",
 		Aliases: []string{"tx"},
 		Short:   "Transaction commands to destination chain",
-		Long: strings.TrimSpace(`Commands to create transactions on destination chains.
+		Long: fmt.Sprintf(
+			`Commands to create transactions on destination chains.
 
-Make sure that chains are properly configured to relay over by using the 'falcon chains list' command.`),
+Make sure that chains are properly configured to relay over by using the '%s chains list' command.`,
+			app.Name,
+		),
 	}
 
 	cmd.AddCommand(
@@ -38,7 +41,7 @@ func txRelayCmd(app *relayer.App) *cobra.Command {
 		Args:    withUsage(cobra.ExactArgs(1)),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s tx relay 1, 		# relay tunnelID 1's pending packets
-$ %s tx relay 1 --force	# relay tunnelID 1's pending packets regardless of its active status on BandChain`, appName, appName)),
+$ %s tx relay 1 --force	# relay tunnelID 1's pending packets regardless of its active status on BandChain`, app.Name, app.Name)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tunnelID, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,16 +25,16 @@ type versionInfo struct {
 }
 
 // VersionCmd returns a command that prints the falcon version information.
-func VersionCmd(_ *relayer.App) *cobra.Command {
+func VersionCmd(app *relayer.App) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:     "version",
 		Aliases: []string{"v"},
-		Short:   "Print the falcon version info",
+		Short:   fmt.Sprintf("Print the %s version info", app.Name),
 		Args:    withUsage(cobra.NoArgs),
 		Example: strings.TrimSpace(fmt.Sprintf(`
 $ %s version
 $ %s v`,
-			appName, appName,
+			app.Name, app.Name,
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			commit := Commit

--- a/relayer/app.go
+++ b/relayer/app.go
@@ -18,6 +18,7 @@ import (
 
 // App is the main application struct.
 type App struct {
+	Name   string
 	Log    *zap.Logger
 	Config *config.Config
 	Store  store.Store
@@ -29,12 +30,14 @@ type App struct {
 
 // NewApp creates a new App instance.
 func NewApp(
+	name string,
 	log *zap.Logger,
 	config *config.Config,
 	passphrase string,
 	store store.Store,
 ) *App {
 	app := App{
+		Name:       name,
 		Log:        log,
 		Config:     config,
 		Store:      store,


### PR DESCRIPTION
Fixed: 
use app.Name instead of global variable appName.

## Implementation details

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)
